### PR TITLE
Fixed multinode enabler entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dynamic = ["version", "dependencies"]
 
 [project.entry-points."kedro.hooks"]
-multinode_enabler = "kedro_partitioned.plugins:multinode_enabler"
+multinode_enabler = "kedro_partitioned.plugin:multinode_enabler"
 
 [tool.setuptools.dynamic]
 version = { attr = "kedro_partitioned.__version__" }


### PR DESCRIPTION
## Problem

Could not start a pipeline because multinode enabler hook was pointing to the wrong place

## Solution

Fixed entrypoint in pyprojec

@ms-cmy , a good first test is to write an integration test with `kedro run`
