### PR TITLE
Remove multithread to load input of node

### DIFF
--- a/kedro_partitioned/__init__.py
+++ b/kedro_partitioned/__init__.py
@@ -1,3 +1,3 @@
-"""Kedro-partitioned package."""
+"""Kedro-partitioned main package."""
 
 __version__ = "0.2.2-rc.1"

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -353,25 +353,18 @@ class _SlicerNode(_CustomizedFuncNode):
         self._filter = filter
         self._configurator = configurator
         self.split_function = split_function
-        
-        
-        
+
         inputs = tolist(partitioned_inputs) + optionaltolist(configurator)
         outputs = self._add_slicer_suffix(partitioned_outputs)
         if namespace:
             inputs = [ f"{namespace}.{inp}" for inp in inputs]
         if namespace:
             outputs = [f"{namespace}.{out}" for out in outputs]
-            
-
-        
-        
-        
         
         super().__init__(
             func=nonefy,
-            inputs=tolist(partitioned_inputs) + optionaltolist(configurator),
-            outputs=self._add_slicer_suffix(partitioned_outputs),
+            inputs=inputs,
+            outputs=outputs,
             name=name,
             tags=tags,
             confirms=confirms,
@@ -1011,8 +1004,8 @@ class _SynchronizationNode(_CustomizedFuncNode):
 
         super().__init__(
             func=nonefy,
-            inputs=self._extract_inputs(multinodes),
-            outputs=tolist(partitioned_outputs),
+            inputs=inputs,
+            outputs=outputs,
             name=self._add_synchronization_suffix(name),
             tags=tags,
             confirms=confirms,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -426,6 +426,7 @@ class _SlicerNode(_CustomizedFuncNode):
         outputs = self._original_output
         if "outputs" in overwrite_params.keys():
             outputs = overwrite_params["outputs"]
+            print(outputs)
         
         params = {
             "partitioned_inputs": inputs,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -789,10 +789,13 @@ class _MultiNode(_CustomizedFuncNode):
                 for elem in overwrite_params["inputs"]:
                     print(elem)
                     if is_partitioned_input(self._partitioned_inputs, elem):
+                        print("partitioned_input")
                         inputs.append(elem)
                     elif is_partitioned_input([self._slicer.json_output], elem):
+                        print("slicer")
                         slicer.append(elem)
                     else:
+                        print("other")
                         other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], str):
                 if is_partitioned_input(self._partitioned_inputs, elem):

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -933,7 +933,7 @@ class _MultiNode(_CustomizedFuncNode):
         @wraps(self._func)
         def fn(*args: Any) -> Any:
             slices, partitioneds, configurators, other_inputs = self._extract_args(args)
-
+            print(slices)
             partitioneds = self._slice_inputs(slices, partitioneds)
             func_return = self._original_func(*partitioneds, *other_inputs)
             if isinstance(func_return, dict):

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -1112,18 +1112,18 @@ class _SynchronizationNode(_CustomizedFuncNode):
         if "inputs" in overwrite_params.keys():
             if isinstance(overwrite_params["inputs"], list):
                 for elem in overwrite_params["inputs"]:
-                    if is_partitioned_input(self._partitioned_inputs, elem):
+                    if is_partitioned_input(self._multinodes, elem):
                         inputs.append(elem)
                     else:
                         other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], str):
-                if is_partitioned_input(self._partitioned_inputs, elem):
+                if is_partitioned_input(self._multinodes, elem):
                     inputs.append(elem)
                 else:
                     other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], dict):
                 for key, value in overwrite_params["inputs"].items():
-                    if is_partitioned_input(self._partitioned_inputs, key):
+                    if is_partitioned_input(self._multinodes, key):
                         inputs.append(value)
                     else:
                         other_inputs.append(elem)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -796,6 +796,7 @@ class _MultiNode(_CustomizedFuncNode):
                 raise ValueError("Inputs not str, list or dict")
         else:
             inputs = self._partitioned_inputs
+            other_inputs = self._other_inputs
             
         if len(other_inputs) == 0:
             other_inputs = None

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -783,11 +783,12 @@ class _MultiNode(_CustomizedFuncNode):
             other_inputs = []
             slicer = []
             if isinstance(overwrite_params["inputs"], list):
+                print([self._slicer.json_output])
+                print(overwrite_params["inputs"])
                 for elem in overwrite_params["inputs"]:
                     if is_partitioned_input(self._partitioned_inputs, elem):
                         inputs.append(elem)
                     elif is_partitioned_input([self._slicer.json_output], elem):
-                        print(other_inputs)
                         slicer.append(elem)
                     else:
                         other_inputs.append(elem)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -784,29 +784,26 @@ class _MultiNode(_CustomizedFuncNode):
             other_inputs = []
             slicer = []
             if isinstance(overwrite_params["inputs"], list):
-                print([self._slicer.json_output])
-                print(overwrite_params["inputs"])
-                print()
                 for elem in overwrite_params["inputs"]:
-                    if is_partitioned_input(self._partitioned_inputs, elem):
-                        inputs.append(elem)
-                    elif is_partitioned_input([self._slicer.json_output], elem):
+                    if is_partitioned_input([self._slicer.json_output], elem):
                         slicer.append(elem)
+                    elif is_partitioned_input(self._partitioned_inputs, elem):
+                        inputs.append(elem)
                     else:
                         other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], str):
-                if is_partitioned_input(self._partitioned_inputs, elem):
-                    inputs.append(elem)
-                elif is_partitioned_input(self._slicer.json_output, elem):
+                if is_partitioned_input(self._slicer.json_output, elem):
                     slicer.append(elem)
+                elif is_partitioned_input(self._partitioned_inputs, elem):
+                    inputs.append(elem)
                 else:
                     other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], dict):
                 for key, value in overwrite_params["inputs"].items():
-                    if is_partitioned_input(self._partitioned_inputs, key):
-                        inputs.append(value)
-                    elif is_partitioned_input(self._slicer.json_output, elem):
+                    if is_partitioned_input(self._slicer.json_output, elem):
                         slicer.append(value)
+                    elif is_partitioned_input(self._partitioned_inputs, key):
+                        inputs.append(value)
                     else:
                         other_inputs.append(value)
             else:

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -678,7 +678,7 @@ class _MultiNode(_CustomizedFuncNode):
         
         func: Callable,
         name: str,
-        slicer,
+        slicer: Union[_SlicerNode, str],
         partitioned_inputs: Union[str, List[str]],
         partitioned_outputs: Union[None, str, List[str]],
         slice_id: int,
@@ -704,7 +704,7 @@ class _MultiNode(_CustomizedFuncNode):
 
         self._point_to_matches(previous_nodes)
                 
-        if isinstance(self._slicer, _MultiNode):
+        if isinstance(self._slicer, _SlicerNode):
             inputs = (
                     [self.slicer_output]
                     + tolist(self.partitioned_inputs)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -1070,11 +1070,8 @@ class _MultiNode(_CustomizedFuncNode):
 
         @wraps(self._func)
         def fn(*args: Any) -> Any:
-            print(args)
             slices, partitioneds, configurators, other_inputs = self._extract_args(args)
-            print(slices, partitioneds)
             partitioneds = self._slice_inputs(slices, partitioneds)
-            print(partitioneds)
             func_return = self._original_func(*partitioneds, *other_inputs)
             if isinstance(func_return, dict):
                 return [func_return]

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -916,6 +916,7 @@ class _MultiNode(_CustomizedFuncNode):
         Union[None, Dict[str, _Configurator]],
         List[Any],
     ]:
+        print(args)
         slices, args = self._extract_slices(args)
         partitioneds, args = self._extract_partitioneds(args)
         configurators, args = self._extract_configurators(args)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -353,6 +353,21 @@ class _SlicerNode(_CustomizedFuncNode):
         self._filter = filter
         self._configurator = configurator
         self.split_function = split_function
+        
+        
+        
+        inputs = tolist(partitioned_inputs) + optionaltolist(configurator)
+        outputs = self._add_slicer_suffix(partitioned_outputs)
+        if namespace:
+            inputs = [ f"{namespace}.{inp}" for inp in inputs]
+        if namespace:
+            outputs = [f"{namespace}.{out}" for out in outputs]
+            
+
+        
+        
+        
+        
         super().__init__(
             func=nonefy,
             inputs=tolist(partitioned_inputs) + optionaltolist(configurator),
@@ -641,16 +656,26 @@ class _MultiNode(_CustomizedFuncNode):
         self._configurator = configurator
 
         self._point_to_matches(previous_nodes)
+        
+        
+        inputs = (
+                    [self.slicer_output]
+                    + tolist(self.partitioned_inputs)
+                    + optionaltolist(self._configurator)
+                    + tolist(self.other_inputs)
+                )
+        outputs = self.partitioned_outputs
+
+        if namespace:
+            inputs = [ f"{namespace}.{inp}" for inp in inputs]
+            
+        if namespace:
+            outputs = [f"{namespace}.{out}" for out in outputs]
 
         super().__init__(
             func=func,
-            inputs=(
-                [self.slicer_output]
-                + tolist(self.partitioned_inputs)
-                + optionaltolist(self._configurator)
-                + tolist(self.other_inputs)
-            ),
-            outputs=self.partitioned_outputs,
+            inputs=inputs,
+            outputs=outputs,
             name=self._add_slice_suffix(name),
             tags=tags,
             confirms=confirms,
@@ -974,6 +999,15 @@ class _SynchronizationNode(_CustomizedFuncNode):
     ):
         self._multinodes = multinodes
         self._partitioned_outputs = partitioned_outputs
+
+        inputs = self._extract_inputs(multinodes)
+        outputs = tolist(partitioned_outputs)
+
+        if namespace:
+            inputs = [ f"{namespace}.{inp}" for inp in inputs]
+            
+        if namespace:
+            outputs = [f"{namespace}.{out}" for out in outputs]
 
         super().__init__(
             func=nonefy,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -23,7 +23,6 @@ from typing_extensions import Literal, NotRequired
 
 from kedro.pipeline.node import Node
 from kedro.pipeline import node
-from kedro.pipeline.modular_pipeline.pipeline._pro
 
 from kedro_partitioned.utils.constants import MAX_NODES, MAX_WORKERS
 from kedro_partitioned.utils.other import (

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -808,7 +808,7 @@ class _MultiNode(_CustomizedFuncNode):
             "confirms": self._confirms,
             "configurator": self._configurator,
         }
-        params.update(overwrite_params)   #{k: v for k, v in overwrite_params.items() if k in params})	
+        params.update({k: v for k, v in overwrite_params.items() if k in params})
         return self.__class__(**params)
 
     def _validate_inputs(self, func: Any, inputs: Any):

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -678,7 +678,7 @@ class _MultiNode(_CustomizedFuncNode):
         
         func: Callable,
         name: str,
-        slicer: _SlicerNode | str,
+        slicer: Union[_SlicerNode, str],
         partitioned_inputs: Union[str, List[str]],
         partitioned_outputs: Union[None, str, List[str]],
         slice_id: int,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -699,15 +699,7 @@ class _MultiNode(_CustomizedFuncNode):
         self._configurator = configurator
 
         self._point_to_matches(previous_nodes)
-        
-        
-        inputs = (
-                    [self.slicer_output]
-                    + tolist(self.partitioned_inputs)
-                    + optionaltolist(self._configurator)
-                    + tolist(self.other_inputs)
-                )
-        
+                
         if self._slicer:
             inputs = (
                     [self.slicer_output]

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -359,7 +359,7 @@ class _SlicerNode(_CustomizedFuncNode):
         if namespace:
             inputs = [ f"{namespace}.{inp}" for inp in inputs]
         if namespace:
-            outputs = [f"{namespace}.{out}" for out in outputs]
+            outputs = f"{namespace}.{outputs}"
         
         super().__init__(
             func=nonefy,
@@ -660,7 +660,7 @@ class _MultiNode(_CustomizedFuncNode):
         outputs = self.partitioned_outputs
 
         if namespace:
-            inputs = [ f"{namespace}.{inp}" for inp in inputs]
+            inputs = [f"{namespace}.{inp}" for inp in inputs]
             
         if namespace:
             outputs = [f"{namespace}.{out}" for out in outputs]

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -788,7 +788,7 @@ class _MultiNode(_CustomizedFuncNode):
         if len(other_inputs) == 0:
             other_inputs = None
                     
-        outputs = self._original_output
+        outputs = self._partitioned_outputs
         if "outputs" in overwrite_params.keys():
             outputs = overwrite_params["outputs"]
 
@@ -1100,7 +1100,7 @@ class _SynchronizationNode(_CustomizedFuncNode):
     def _copy(self, **overwrite_params: Any) -> _SynchronizationNode:
         
                     
-        outputs = self._original_output
+        outputs = self._partitioned_outputs
         if "outputs" in overwrite_params.keys():
             outputs = overwrite_params["outputs"]
 

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -866,6 +866,8 @@ class _MultiNode(_CustomizedFuncNode):
         ]
 
     def _get_slice(self, slices: List[List[str]]) -> Set[str]:
+        print(slices)
+        print(self.slice_id)
         return set(slices[self.slice_id])
 
     def _slice_inputs(
@@ -1001,7 +1003,6 @@ class _SynchronizationNode(_CustomizedFuncNode):
             "tags": self._tags,
             "confirms": self._confirms,
         }
-        print(overwrite_params)
         params.update({k: v for k, v in overwrite_params.items() if k in params})
         return self.__class__(**params)
 

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -803,7 +803,6 @@ class _MultiNode(_CustomizedFuncNode):
                 else:
                     other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], dict):
-                print(overwrite_params["inputs"])
                 for key, value in overwrite_params["inputs"].items():
                     if is_partitioned_input(self._slicer.json_output, elem):
                         slicer.append(value)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -784,6 +784,9 @@ class _MultiNode(_CustomizedFuncNode):
             other_inputs = []
             slicer = []
             if isinstance(overwrite_params["inputs"], list):
+                print([self._slicer.json_output])
+                print(overwrite_params["inputs"])
+                print()
                 for elem in overwrite_params["inputs"]:
                     if is_partitioned_input(self._partitioned_inputs, elem):
                         inputs.append(elem)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -387,7 +387,7 @@ class _SlicerNode(_CustomizedFuncNode):
             "configurator": self._configurator,
             "filter": self._filter,
         }
-        params.update(overwrite_params)
+	params.update({k: v for k, v in overwrite_params.items() if k in params})
         return self.__class__(**params)
 
     @classmethod
@@ -711,7 +711,7 @@ class _MultiNode(_CustomizedFuncNode):
             "confirms": self._confirms,
             "configurator": self._configurator,
         }
-        params.update(overwrite_params)
+        params.update({k: v for k, v in overwrite_params.items() if k in params})	
         return self.__class__(**params)
 
     def _validate_inputs(self, func: Any, inputs: Any):
@@ -1001,7 +1001,7 @@ class _SynchronizationNode(_CustomizedFuncNode):
             "tags": self._tags,
             "confirms": self._confirms,
         }
-        params.update(overwrite_params)
+        params.update({k: v for k, v in overwrite_params.items() if k in params})
         return self.__class__(**params)
 
     @classmethod

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -803,6 +803,7 @@ class _MultiNode(_CustomizedFuncNode):
                 else:
                     other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], dict):
+                print(overwrite_params["inputs"])
                 for key, value in overwrite_params["inputs"].items():
                     if is_partitioned_input(self._slicer.json_output, elem):
                         slicer.append(value)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -998,6 +998,7 @@ class _MultiNode(_CustomizedFuncNode):
         ]
 
     def _get_slice(self, slices: List[List[str]]) -> Set[str]:
+        print(slices)
         return set(slices[self.slice_id])
 
     def _slice_inputs(

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -678,7 +678,7 @@ class _MultiNode(_CustomizedFuncNode):
         
         func: Callable,
         name: str,
-        slicer: Union[_SlicerNode, str],
+        slicer,
         partitioned_inputs: Union[str, List[str]],
         partitioned_outputs: Union[None, str, List[str]],
         slice_id: int,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -802,7 +802,6 @@ class _MultiNode(_CustomizedFuncNode):
         if "outputs" in overwrite_params.keys():
             outputs = overwrite_params["outputs"]
 
-        print(outputs)
         
         params = {
             "slicer": slicer,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -1083,12 +1083,6 @@ class _SynchronizationNode(_CustomizedFuncNode):
         inputs = self._extract_inputs(multinodes)
         outputs = tolist(partitioned_outputs)
 
-        # if namespace:
-        #     inputs = [ f"{namespace}.{inp}" for inp in inputs]
-            
-        # if namespace:
-        #     outputs = [f"{namespace}.{out}" for out in outputs]
-
         super().__init__(
             func=nonefy,
             inputs=inputs,
@@ -1137,13 +1131,13 @@ class _SynchronizationNode(_CustomizedFuncNode):
             raise ValueError("Other_inputs not empty for slicer node")
 
                     
-        outputs = self._partitioned_outputs
+        out_outputs = self._partitioned_outputs
         if "outputs" in overwrite_params.keys():
-            outputs = overwrite_params["outputs"]
+            out_outputs = overwrite_params["outputs"]
 
         params = {
             "multinodes": inputs,
-            "partitioned_outputs": outputs,
+            "partitioned_outputs": out_outputs,
             "name": self._name,
             "namespace": self._namespace,
             "tags": self._tags,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -678,6 +678,7 @@ class _MultiNode(_CustomizedFuncNode):
         
         func: Callable,
         name: str,
+        slicer: _SlicerNode | str,
         partitioned_inputs: Union[str, List[str]],
         partitioned_outputs: Union[None, str, List[str]],
         slice_id: int,
@@ -688,7 +689,6 @@ class _MultiNode(_CustomizedFuncNode):
         namespace: str = None,
         previous_nodes: List[_MultiNode] = [],
         configurator: str = None,
-        slicer: _SlicerNode = None,
     ):
         self._slicer = slicer
 
@@ -704,7 +704,7 @@ class _MultiNode(_CustomizedFuncNode):
 
         self._point_to_matches(previous_nodes)
                 
-        if self._slicer:
+        if isinstance(self._slicer, _MultiNode):
             inputs = (
                     [self.slicer_output]
                     + tolist(self.partitioned_inputs)
@@ -713,7 +713,8 @@ class _MultiNode(_CustomizedFuncNode):
                 )
         else:
             inputs = (
-                    tolist(self.partitioned_inputs)
+                    [self._slicer]
+                    + tolist(self.partitioned_inputs)
                     + optionaltolist(self._configurator)
                     + tolist(self.other_inputs)
                 )
@@ -810,8 +811,7 @@ class _MultiNode(_CustomizedFuncNode):
             
             if len(other_inputs) == 0:
                 other_inputs = None
-            inputs = slicer + inputs
-            slicer = None
+            slicer = slicer[0]
         else:
             inputs = self._partitioned_inputs
             other_inputs = self._other_inputs

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -783,19 +783,12 @@ class _MultiNode(_CustomizedFuncNode):
             other_inputs = []
             slicer = []
             if isinstance(overwrite_params["inputs"], list):
-                print([self._slicer.json_output])
-                print(self._partitioned_inputs)
-                print(overwrite_params["inputs"])
                 for elem in overwrite_params["inputs"]:
-                    print(elem)
                     if is_partitioned_input(self._partitioned_inputs, elem):
-                        print("partitioned_input")
                         inputs.append(elem)
                     elif is_partitioned_input([self._slicer.json_output], elem):
-                        print("slicer")
                         slicer.append(elem)
                     else:
-                        print("other")
                         other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], str):
                 if is_partitioned_input(self._partitioned_inputs, elem):

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -1081,7 +1081,13 @@ class _SynchronizationNode(_CustomizedFuncNode):
         self._multinodes = multinodes
         self._partitioned_outputs = partitioned_outputs
 
-        inputs = self._extract_inputs(multinodes)
+        
+        def is_list_of_strings(var):
+            return isinstance(var, list) and all(isinstance(item, str) for item in var)
+        if is_list_of_strings(self._multinodes):
+            inputs = self._multinodes
+        else:
+            inputs = self._extract_inputs(multinodes)
         outputs = tolist(partitioned_outputs)
 
         super().__init__(

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -426,7 +426,8 @@ class _SlicerNode(_CustomizedFuncNode):
         outputs = self._original_output
         if "outputs" in overwrite_params.keys():
             outputs = overwrite_params["outputs"]
-            print(outputs)
+            if isinstance(outputs, str):
+                outputs = self._remove_slicer_suffix(outputs)
         
         params = {
             "partitioned_inputs": inputs,
@@ -441,6 +442,14 @@ class _SlicerNode(_CustomizedFuncNode):
         }
         params.update({k: v for k, v in overwrite_params.items() if k in params})
         return self.__class__(**params)
+
+    @classmethod
+    def _remove_slicer_suffix(cls, string: str) -> str:
+        return (
+            string
+            if not string.endswith(cls.SLICER_SUFFIX)
+            else string[:-len(cls.SLICER_SUFFIX)]
+        )
 
     @classmethod
     def _add_slicer_suffix(cls, string: str) -> str:

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -786,7 +786,7 @@ class _MultiNode(_CustomizedFuncNode):
                 for elem in overwrite_params["inputs"]:
                     if is_partitioned_input(self._partitioned_inputs, elem):
                         inputs.append(elem)
-                    elif is_partitioned_input(self._slicer.json_output, elem):
+                    elif is_partitioned_input([self._slicer.json_output], elem):
                         print(other_inputs)
                         slicer.append(elem)
                     else:

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -773,8 +773,6 @@ class _MultiNode(_CustomizedFuncNode):
             other_inputs = []
             slicer = None
             if isinstance(overwrite_params["inputs"], list):
-                print(self._partitioned_inputs)
-                print(overwrite_params["inputs"])
                 for elem in overwrite_params["inputs"]:
                     if is_partitioned_input(self._partitioned_inputs, elem):
                         inputs.append(elem)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -363,8 +363,8 @@ class _SlicerNode(_CustomizedFuncNode):
         self._configurator = configurator
         self.split_function = split_function
 
-        inputs = tolist(partitioned_inputs) + optionaltolist(configurator)
-        outputs = self._add_slicer_suffix(partitioned_outputs)
+        #inputs = 
+        #outputs = 
         # if namespace:
         #     inputs = [ f"{namespace}.{inp}" for inp in inputs]
         # if namespace:
@@ -372,8 +372,8 @@ class _SlicerNode(_CustomizedFuncNode):
         
         super().__init__(
             func=nonefy,
-            inputs=inputs,
-            outputs=outputs,
+            inputs=tolist(partitioned_inputs) + optionaltolist(configurator),
+            outputs=self._add_slicer_suffix(partitioned_outputs),
             name=name,
             tags=tags,
             confirms=confirms,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -802,6 +802,7 @@ class _MultiNode(_CustomizedFuncNode):
         if "outputs" in overwrite_params.keys():
             outputs = overwrite_params["outputs"]
 
+        print(outputs)
         
         params = {
             "slicer": slicer,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -949,7 +949,6 @@ class _MultiNode(_CustomizedFuncNode):
         @wraps(self._func)
         def fn(*args: Any) -> Any:
             slices, partitioneds, configurators, other_inputs = self._extract_args(args)
-            print(slices)
             partitioneds = self._slice_inputs(slices, partitioneds)
             func_return = self._original_func(*partitioneds, *other_inputs)
             if isinstance(func_return, dict):

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -765,7 +765,7 @@ class _MultiNode(_CustomizedFuncNode):
         ]
 
     # required for inheritance
-    def _copy(self, **overwrite_params: Any) -> _MultiNode:            
+    def _copy(self, **overwrite_params: Any) -> _MultiNode:
         
         inputs = []
         other_inputs = []
@@ -774,8 +774,8 @@ class _MultiNode(_CustomizedFuncNode):
             slicer = None
             if isinstance(overwrite_params["inputs"], list):
                 print(self._partitioned_inputs)
+                print(overwrite_params["inputs"])
                 for elem in overwrite_params["inputs"]:
-                    print(elem)
                     if is_partitioned_input(self._partitioned_inputs, elem):
                         inputs.append(elem)
                     else:
@@ -797,7 +797,6 @@ class _MultiNode(_CustomizedFuncNode):
         else:
             inputs = self._partitioned_inputs
             
-        print(other_inputs)
         if len(other_inputs) == 0:
             other_inputs = None
                     

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -1112,18 +1112,18 @@ class _SynchronizationNode(_CustomizedFuncNode):
         if "inputs" in overwrite_params.keys():
             if isinstance(overwrite_params["inputs"], list):
                 for elem in overwrite_params["inputs"]:
-                    if is_partitioned_input(self._multinodes, elem):
+                    if is_partitioned_input(self.inputs, elem):
                         inputs.append(elem)
                     else:
                         other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], str):
-                if is_partitioned_input(self._multinodes, elem):
+                if is_partitioned_input(self.inputs, elem):
                     inputs.append(elem)
                 else:
                     other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], dict):
                 for key, value in overwrite_params["inputs"].items():
-                    if is_partitioned_input(self._multinodes, key):
+                    if is_partitioned_input(self.inputs, key):
                         inputs.append(value)
                     else:
                         other_inputs.append(elem)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -1001,6 +1001,7 @@ class _SynchronizationNode(_CustomizedFuncNode):
             "tags": self._tags,
             "confirms": self._confirms,
         }
+        print(overwrite_params)
         params.update({k: v for k, v in overwrite_params.items() if k in params})
         return self.__class__(**params)
 

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -866,8 +866,6 @@ class _MultiNode(_CustomizedFuncNode):
         ]
 
     def _get_slice(self, slices: List[List[str]]) -> Set[str]:
-        print(slices)
-        print(self.slice_id)
         return set(slices[self.slice_id])
 
     def _slice_inputs(
@@ -916,7 +914,6 @@ class _MultiNode(_CustomizedFuncNode):
         Union[None, Dict[str, _Configurator]],
         List[Any],
     ]:
-        print(args)
         slices, args = self._extract_slices(args)
         partitioneds, args = self._extract_partitioneds(args)
         configurators, args = self._extract_configurators(args)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -671,7 +671,7 @@ class _MultiNode(_CustomizedFuncNode):
 
     def __init__(
         self,
-        slicer: _SlicerNode,
+        
         func: Callable,
         name: str,
         partitioned_inputs: Union[str, List[str]],
@@ -684,6 +684,7 @@ class _MultiNode(_CustomizedFuncNode):
         namespace: str = None,
         previous_nodes: List[_MultiNode] = [],
         configurator: str = None,
+        slicer: _SlicerNode = None,
     ):
         self._slicer = slicer
 
@@ -706,6 +707,21 @@ class _MultiNode(_CustomizedFuncNode):
                     + optionaltolist(self._configurator)
                     + tolist(self.other_inputs)
                 )
+        
+        if self._slicer:
+            inputs = (
+                    [self.slicer_output]
+                    + tolist(self.partitioned_inputs)
+                    + optionaltolist(self._configurator)
+                    + tolist(self.other_inputs)
+                )
+        else:
+            inputs = (
+                    tolist(self.partitioned_inputs)
+                    + optionaltolist(self._configurator)
+                    + tolist(self.other_inputs)
+                )
+        
         outputs = self.partitioned_outputs
 
         # if namespace:
@@ -767,7 +783,9 @@ class _MultiNode(_CustomizedFuncNode):
         
         inputs = []
         other_inputs = []
+        slicer = self._slicer
         if "inputs" in overwrite_params.keys():
+            slicer = None
             if isinstance(overwrite_params["inputs"], list):
                 for elem in overwrite_params["inputs"]:
                     if is_partitioned_input(self._partitioned_inputs, elem):
@@ -799,9 +817,8 @@ class _MultiNode(_CustomizedFuncNode):
             outputs = overwrite_params["outputs"]
 
         
-        
         params = {
-            "slicer": self._slicer,
+            "slicer": slicer,
             "func": self._func,
             "partitioned_inputs": inputs,
             "other_inputs": other_inputs,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -356,10 +356,10 @@ class _SlicerNode(_CustomizedFuncNode):
 
         inputs = tolist(partitioned_inputs) + optionaltolist(configurator)
         outputs = self._add_slicer_suffix(partitioned_outputs)
-        if namespace:
-            inputs = [ f"{namespace}.{inp}" for inp in inputs]
-        if namespace:
-            outputs = f"{namespace}.{outputs}"
+        # if namespace:
+        #     inputs = [ f"{namespace}.{inp}" for inp in inputs]
+        # if namespace:
+        #     outputs = f"{namespace}.{outputs}"
         
         super().__init__(
             func=nonefy,
@@ -659,11 +659,11 @@ class _MultiNode(_CustomizedFuncNode):
                 )
         outputs = self.partitioned_outputs
 
-        if namespace:
-            inputs = [f"{namespace}.{inp}" for inp in inputs]
+        # if namespace:
+        #     inputs = [f"{namespace}.{inp}" for inp in inputs]
             
-        if namespace:
-            outputs = [f"{namespace}.{out}" for out in outputs]
+        # if namespace:
+        #     outputs = [f"{namespace}.{out}" for out in outputs]
 
         super().__init__(
             func=func,
@@ -996,11 +996,11 @@ class _SynchronizationNode(_CustomizedFuncNode):
         inputs = self._extract_inputs(multinodes)
         outputs = tolist(partitioned_outputs)
 
-        if namespace:
-            inputs = [ f"{namespace}.{inp}" for inp in inputs]
+        # if namespace:
+        #     inputs = [ f"{namespace}.{inp}" for inp in inputs]
             
-        if namespace:
-            outputs = [f"{namespace}.{out}" for out in outputs]
+        # if namespace:
+        #     outputs = [f"{namespace}.{out}" for out in outputs]
 
         super().__init__(
             func=nonefy,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -788,6 +788,7 @@ class _MultiNode(_CustomizedFuncNode):
                         inputs.append(elem)
                     else:
                         other_inputs.append(elem)
+                        print(other_inputs)
             elif isinstance(overwrite_params["inputs"], str):
                 if is_partitioned_input(self._partitioned_inputs, elem):
                     inputs.append(elem)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -421,13 +421,7 @@ class _SlicerNode(_CustomizedFuncNode):
             inputs = self._partitioned_inputs
             
         if len(other_inputs) > 0:
-            raise ValueError("Other_inputs not empty for slicer node")
-        print("over")
-        print(overwrite_params)
-        print("input")
-        print(inputs)
-        print()
-        
+            raise ValueError("Other_inputs not empty for slicer node")        
         
         outputs = self._original_output
         if "outputs" in overwrite_params.keys():
@@ -1113,14 +1107,42 @@ class _SynchronizationNode(_CustomizedFuncNode):
 
     # required for inheritance
     def _copy(self, **overwrite_params: Any) -> _SynchronizationNode:
-        
+        inputs = []
+        other_inputs = []
+        if "inputs" in overwrite_params.keys():
+            if isinstance(overwrite_params["inputs"], list):
+                for elem in overwrite_params["inputs"]:
+                    if is_partitioned_input(self._partitioned_inputs, elem):
+                        inputs.append(elem)
+                    else:
+                        other_inputs.append(elem)
+            elif isinstance(overwrite_params["inputs"], str):
+                if is_partitioned_input(self._partitioned_inputs, elem):
+                    inputs.append(elem)
+                else:
+                    other_inputs.append(elem)
+            elif isinstance(overwrite_params["inputs"], dict):
+                for key, value in overwrite_params["inputs"].items():
+                    if is_partitioned_input(self._partitioned_inputs, key):
+                        inputs.append(value)
+                    else:
+                        other_inputs.append(elem)
+
+            else:
+                raise ValueError("Inputs not str, list or dict")
+        else:
+            inputs = self._multinodes
+            
+        if len(other_inputs) > 0:
+            raise ValueError("Other_inputs not empty for slicer node")
+
                     
         outputs = self._partitioned_outputs
         if "outputs" in overwrite_params.keys():
             outputs = overwrite_params["outputs"]
 
         params = {
-            "multinodes": self._multinodes,
+            "multinodes": inputs,
             "partitioned_outputs": outputs,
             "name": self._name,
             "namespace": self._namespace,

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -795,6 +795,7 @@ class _MultiNode(_CustomizedFuncNode):
         else:
             inputs = self._partitioned_inputs
             
+        print(other_inputs)
         if len(other_inputs) == 0:
             other_inputs = None
                     

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -849,16 +849,16 @@ class _MultiNode(_CustomizedFuncNode):
         return self._slicer.json_output
 
     @classmethod
-    def _remove_slice_suffix(cls, string: Union[str, List[str]], slice_id: int) -> str:
+    def _remove_slice_suffix(cls, list_string: Union[str, List[str]], slice_id: int) -> str:
         return firstorlist(
             [
                 
                 (
-                    string
-                    if not string.endswith(f"{cls.SLICE_SUFFIX}{slice_id}")
-                    else string[:-len(f"{cls.SLICE_SUFFIX}{slice_id}")]
+                    el
+                    if not el.endswith(f"{cls.SLICE_SUFFIX}{slice_id}")
+                    else el[:-len(f"{cls.SLICE_SUFFIX}{slice_id}")]
                 )
-                for el in tolist(string)
+                for el in tolist(list_string)
             ]
         )
 

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -773,7 +773,9 @@ class _MultiNode(_CustomizedFuncNode):
         if "inputs" in overwrite_params.keys():
             slicer = None
             if isinstance(overwrite_params["inputs"], list):
+                print(self._partitioned_inputs)
                 for elem in overwrite_params["inputs"]:
+                    print(elem)
                     if is_partitioned_input(self._partitioned_inputs, elem):
                         inputs.append(elem)
                     else:

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -998,7 +998,6 @@ class _MultiNode(_CustomizedFuncNode):
         ]
 
     def _get_slice(self, slices: List[List[str]]) -> Set[str]:
-        print(slices)
         return set(slices[self.slice_id])
 
     def _slice_inputs(
@@ -1063,8 +1062,11 @@ class _MultiNode(_CustomizedFuncNode):
 
         @wraps(self._func)
         def fn(*args: Any) -> Any:
+            print(args)
             slices, partitioneds, configurators, other_inputs = self._extract_args(args)
+            print(slices, partitioneds)
             partitioneds = self._slice_inputs(slices, partitioneds)
+            print(partitioneds)
             func_return = self._original_func(*partitioneds, *other_inputs)
             if isinstance(func_return, dict):
                 return [func_return]

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -422,6 +422,12 @@ class _SlicerNode(_CustomizedFuncNode):
             
         if len(other_inputs) > 0:
             raise ValueError("Other_inputs not empty for slicer node")
+        print("over")
+        print(overwrite_params)
+        print("input")
+        print(inputs)
+        print()
+        
         
         outputs = self._original_output
         if "outputs" in overwrite_params.keys():

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -781,30 +781,38 @@ class _MultiNode(_CustomizedFuncNode):
         if "inputs" in overwrite_params.keys():
             inputs = []
             other_inputs = []
-            slicer = None
+            slicer = []
             if isinstance(overwrite_params["inputs"], list):
                 for elem in overwrite_params["inputs"]:
                     if is_partitioned_input(self._partitioned_inputs, elem):
                         inputs.append(elem)
+                    elif is_partitioned_input(self._slicer.json_output, elem):
+                        print(other_inputs)
+                        slicer.append(elem)
                     else:
                         other_inputs.append(elem)
-                        print(other_inputs)
             elif isinstance(overwrite_params["inputs"], str):
                 if is_partitioned_input(self._partitioned_inputs, elem):
                     inputs.append(elem)
+                elif is_partitioned_input(self._slicer.json_output, elem):
+                    slicer.append(elem)
                 else:
                     other_inputs.append(elem)
             elif isinstance(overwrite_params["inputs"], dict):
                 for key, value in overwrite_params["inputs"].items():
                     if is_partitioned_input(self._partitioned_inputs, key):
                         inputs.append(value)
+                    elif is_partitioned_input(self._slicer.json_output, elem):
+                        slicer.append(value)
                     else:
-                        other_inputs.append(elem)
+                        other_inputs.append(value)
             else:
                 raise ValueError("Inputs not str, list or dict")
             
             if len(other_inputs) == 0:
                 other_inputs = None
+            inputs = slicer + inputs
+            slicer = None
         else:
             inputs = self._partitioned_inputs
             other_inputs = self._other_inputs

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -785,7 +785,11 @@ class _MultiNode(_CustomizedFuncNode):
             slicer = []
             if isinstance(overwrite_params["inputs"], list):
                 for elem in overwrite_params["inputs"]:
-                    if is_partitioned_input([self._slicer.json_output], elem):
+                    if isinstance(self._slicer, str):
+                        json_output = [self._slicer]
+                    else:
+                        json_output = [self._slicer.json_output]
+                    if is_partitioned_input(json_output, elem):
                         slicer.append(elem)
                     elif is_partitioned_input(self._partitioned_inputs, elem):
                         inputs.append(elem)

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -812,7 +812,7 @@ class _MultiNode(_CustomizedFuncNode):
         outputs = self._partitioned_outputs
         if "outputs" in overwrite_params.keys():
             outputs = overwrite_params["outputs"]
-
+            outputs = self._remove_slice_suffix(outputs, self._slice_id)
         
         params = {
             "slicer": slicer,
@@ -847,6 +847,21 @@ class _MultiNode(_CustomizedFuncNode):
             str
         """
         return self._slicer.json_output
+
+    @classmethod
+    def _remove_slice_suffix(cls, string: Union[str, List[str]], slice_id: int) -> str:
+        return firstorlist(
+            [
+                
+                (
+                    string
+                    if not string.endswith(f"{cls.SLICE_SUFFIX}{slice_id}")
+                    else string[:-len(f"{cls.SLICE_SUFFIX}{slice_id}")]
+                )
+                for el in tolist(string)
+            ]
+        )
+
 
     @classmethod
     def add_slice_suffix(

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -387,7 +387,7 @@ class _SlicerNode(_CustomizedFuncNode):
             "configurator": self._configurator,
             "filter": self._filter,
         }
-	params.update({k: v for k, v in overwrite_params.items() if k in params})
+        params.update({k: v for k, v in overwrite_params.items() if k in params})
         return self.__class__(**params)
 
     @classmethod

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -784,8 +784,10 @@ class _MultiNode(_CustomizedFuncNode):
             slicer = []
             if isinstance(overwrite_params["inputs"], list):
                 print([self._slicer.json_output])
+                print(self._partitioned_inputs)
                 print(overwrite_params["inputs"])
                 for elem in overwrite_params["inputs"]:
+                    print(elem)
                     if is_partitioned_input(self._partitioned_inputs, elem):
                         inputs.append(elem)
                     elif is_partitioned_input([self._slicer.json_output], elem):

--- a/kedro_partitioned/pipeline/multinode.py
+++ b/kedro_partitioned/pipeline/multinode.py
@@ -767,10 +767,10 @@ class _MultiNode(_CustomizedFuncNode):
     # required for inheritance
     def _copy(self, **overwrite_params: Any) -> _MultiNode:
         
-        inputs = []
-        other_inputs = []
-        slicer = self._slicer
+        
         if "inputs" in overwrite_params.keys():
+            inputs = []
+            other_inputs = []
             slicer = None
             if isinstance(overwrite_params["inputs"], list):
                 print(self._partitioned_inputs)
@@ -791,15 +791,15 @@ class _MultiNode(_CustomizedFuncNode):
                         inputs.append(value)
                     else:
                         other_inputs.append(elem)
-
             else:
                 raise ValueError("Inputs not str, list or dict")
+            
+            if len(other_inputs) == 0:
+                other_inputs = None
         else:
             inputs = self._partitioned_inputs
             other_inputs = self._other_inputs
-            
-        if len(other_inputs) == 0:
-            other_inputs = None
+            slicer = self._slicer
                     
         outputs = self._partitioned_outputs
         if "outputs" in overwrite_params.keys():

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -90,6 +90,7 @@ class MultiNodeEnabler:
 
             elif isinstance(node, _SlicerNode):
                 partitioned = catalog._get_dataset(node.original_output)
+                print(node.original_output)
                 assert isinstance(partitioned, PartitionedDataset), (
                     f'multinode received "{node.original_output}" as a '
                     f"`PartitionedDataset`, although it is a "

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -83,6 +83,7 @@ class MultiNodeEnabler:
                         partitioned, PartitionedDataset
                     ), "multinode cannot have non partitioned outputs"
                     print(slice)
+                    print(original)
                     print(partitioned)
                     catalog.add(slice, deepcopy(partitioned))
 

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -90,7 +90,8 @@ class MultiNodeEnabler:
                     setattr(cpy, 'slice_id', node._slice_id)
 
                     setattr(cpy, 'slice_count', node.slice_count)
-
+                    print(cpy)
+                    print(slice)
                     catalog.add(slice, deepcopy(partitioned))
 
                 for input in node.original_partitioned_inputs:

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -90,7 +90,9 @@ class MultiNodeEnabler:
 
             elif isinstance(node, _SlicerNode):
                 partitioned = catalog._get_dataset(node.original_output)
+                print("lolllllllllllll")
                 print(node.original_output)
+                print("lulllllllllllll")
                 assert isinstance(partitioned, PartitionedDataset), (
                     f'multinode received "{node.original_output}" as a '
                     f"`PartitionedDataset`, although it is a "

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -82,12 +82,9 @@ class MultiNodeEnabler:
                     assert isinstance(
                         partitioned, PartitionedDataset
                     ), "multinode cannot have non partitioned outputs"
-                    print(slice)
-                    print(original)
-                    print(partitioned)
                     
-                    
-                    #catalog.add(slice, deepcopy(partitioned))
+                    if not catalog.exists(slice):                    
+                        catalog.add(slice, deepcopy(partitioned))
 
                 for input in node.original_partitioned_inputs:
                     partitioned = catalog._get_dataset(input)

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -9,6 +9,7 @@ from kedro_datasets.json import JSONDataset
 from kedro_partitioned.pipeline.multinode import _SlicerNode, _MultiNode
 from upath import UPath
 from kedro_datasets.partitions import PartitionedDataset
+from kedro.framework.project import pipelines
 
 
 class MultiNodeEnabler:
@@ -54,7 +55,10 @@ class MultiNodeEnabler:
     >>> catalog._datasets['b-slicer']._protocol
     'http'
     """
-
+    @hook_impl
+    def after_context_created(self, context) -> None:
+        self.pipe = pipelines["__default__"]
+        
     @hook_impl
     def before_pipeline_run(
         self,
@@ -70,7 +74,7 @@ class MultiNodeEnabler:
             catalog (DataCatalog): Catalog of data sources.
         """
         print("apply plugin")
-        for node in pipeline.nodes:
+        for node in self.pipe.nodes:
             if isinstance(node, _MultiNode):
                 for original, slice in zip(
                     node.original_partitioned_outputs, node.partitioned_outputs

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -83,7 +83,7 @@ class MultiNodeEnabler:
                         partitioned, PartitionedDataset
                     ), "multinode cannot have non partitioned outputs"
                     
-                    if not catalog.exists(slice):                    
+                    if not catalog.exists(slice):
                         catalog.add(slice, deepcopy(partitioned))
 
                 for input in node.original_partitioned_inputs:
@@ -95,6 +95,7 @@ class MultiNodeEnabler:
                     )
 
             elif isinstance(node, _SlicerNode):
+                print(node.original_output)
                 partitioned = catalog._get_dataset(node.original_output)
                 assert isinstance(partitioned, PartitionedDataset), (
                     f'multinode received "{node.original_output}" as a '

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -82,6 +82,8 @@ class MultiNodeEnabler:
                     assert isinstance(
                         partitioned, PartitionedDataset
                     ), "multinode cannot have non partitioned outputs"
+                    print(slice)
+                    print(partitioned)
                     catalog.add(slice, deepcopy(partitioned))
 
                 for input in node.original_partitioned_inputs:

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -95,6 +95,7 @@ class MultiNodeEnabler:
                     )
 
             elif isinstance(node, _SlicerNode):
+                print(node.json_output)
                 print(node.original_output)
                 partitioned = catalog._get_dataset(node.original_output)
                 assert isinstance(partitioned, PartitionedDataset), (

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -95,8 +95,6 @@ class MultiNodeEnabler:
                     )
 
             elif isinstance(node, _SlicerNode):
-                print(node.json_output)
-                print(node.original_output)
                 partitioned = catalog._get_dataset(node.original_output)
                 assert isinstance(partitioned, PartitionedDataset), (
                     f'multinode received "{node.original_output}" as a '

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -8,7 +8,7 @@ from kedro.framework.hooks import hook_impl
 from kedro_datasets.json import JSONDataset
 from kedro_partitioned.pipeline.multinode import _SlicerNode, _MultiNode
 from upath import UPath
-from kedro_datasets.partitions import PartitionedDataset
+from kedro_datasets.partitions import PartitionedDataset, MemoryDataset
 
 
 class MultiNodeEnabler:
@@ -76,8 +76,8 @@ class MultiNodeEnabler:
                 ):
                     partitioned = catalog._get_dataset(original)
                     assert isinstance(
-                        partitioned, PartitionedDataset
-                    ), "multinode cannot have non partitioned outputs"
+                        partitioned, (PartitionedDataset, MemoryDataset)
+                    ), "multinode cannot have non-partitioned or non-memory outputs"
                     catalog.add(slice, deepcopy(partitioned))
 
                 for input in node.original_partitioned_inputs:

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -78,7 +78,7 @@ class MultiNodeEnabler:
                 for original, slice in zip(
                     node.original_partitioned_outputs, node.partitioned_outputs
                 ):
-                    partitioned = catalog._get_dataset(slice)
+                    partitioned = catalog._get_dataset(original)
                     assert isinstance(
                         partitioned, PartitionedDataset
                     ), "multinode cannot have non partitioned outputs"

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -78,7 +78,7 @@ class MultiNodeEnabler:
                 for original, slice in zip(
                     node.original_partitioned_outputs, node.partitioned_outputs
                 ):
-                    partitioned = catalog._get_dataset(original)
+                    partitioned = catalog._get_dataset(slice)
                     assert isinstance(
                         partitioned, PartitionedDataset
                     ), "multinode cannot have non partitioned outputs"

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -89,7 +89,6 @@ class MultiNodeEnabler:
                     setattr(cpy, 'slice_count', node.slice_count)
 
                     catalog.add(slice, cpy)
-                    print(original, slice)
 
                 for input in node.original_partitioned_inputs:
                     partitioned = catalog._get_dataset(input)

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -8,7 +8,7 @@ from kedro.framework.hooks import hook_impl
 from kedro_datasets.json import JSONDataset
 from kedro_partitioned.pipeline.multinode import _SlicerNode, _MultiNode
 from upath import UPath
-from kedro_datasets.partitions import PartitionedDataset, MemoryDataset
+from kedro_datasets.partitions import PartitionedDataset
 
 
 class MultiNodeEnabler:
@@ -76,8 +76,8 @@ class MultiNodeEnabler:
                 ):
                     partitioned = catalog._get_dataset(original)
                     assert isinstance(
-                        partitioned, (PartitionedDataset, MemoryDataset)
-                    ), "multinode cannot have non-partitioned or non-memory outputs"
+                        partitioned, PartitionedDataset
+                    ), "multinode cannot have non partitioned outputs"
                     catalog.add(slice, deepcopy(partitioned))
 
                 for input in node.original_partitioned_inputs:

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -73,7 +73,6 @@ class MultiNodeEnabler:
             pipeline (Pipeline): Pipeline to be run.
             catalog (DataCatalog): Catalog of data sources.
         """
-        print("apply plugin")
         for node in self.pipe.nodes:
             if isinstance(node, _MultiNode):
                 for original, slice in zip(

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -69,6 +69,7 @@ class MultiNodeEnabler:
             pipeline (Pipeline): Pipeline to be run.
             catalog (DataCatalog): Catalog of data sources.
         """
+        print("apply plugin")
         for node in pipeline.nodes:
             if isinstance(node, _MultiNode):
                 for original, slice in zip(
@@ -90,9 +91,6 @@ class MultiNodeEnabler:
 
             elif isinstance(node, _SlicerNode):
                 partitioned = catalog._get_dataset(node.original_output)
-                print("lolllllllllllll")
-                print(node.original_output)
-                print("lulllllllllllll")
                 assert isinstance(partitioned, PartitionedDataset), (
                     f'multinode received "{node.original_output}" as a '
                     f"`PartitionedDataset`, although it is a "

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -85,7 +85,9 @@ class MultiNodeEnabler:
                     print(slice)
                     print(original)
                     print(partitioned)
-                    catalog.add(slice, deepcopy(partitioned))
+                    
+                    
+                    #catalog.add(slice, deepcopy(partitioned))
 
                 for input in node.original_partitioned_inputs:
                     partitioned = catalog._get_dataset(input)

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -83,14 +83,13 @@ class MultiNodeEnabler:
                         partitioned, PartitionedDataset
                     ), "multinode cannot have non partitioned outputs"
 
-                    #if not catalog.exists(slice):
-
                     cpy = deepcopy(partitioned)
 
                     setattr(cpy, 'slice_id', node._slice_id)
                     setattr(cpy, 'slice_count', node.slice_count)
 
                     catalog.add(slice, cpy)
+                    print(original, slice)
 
                 for input in node.original_partitioned_inputs:
                     partitioned = catalog._get_dataset(input)

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -88,11 +88,9 @@ class MultiNodeEnabler:
                     cpy = deepcopy(partitioned)
 
                     setattr(cpy, 'slice_id', node._slice_id)
-
                     setattr(cpy, 'slice_count', node.slice_count)
-                    print(cpy)
-                    print(slice)
-                    catalog.add(slice, deepcopy(partitioned))
+
+                    catalog.add(slice, cpy)
 
                 for input in node.original_partitioned_inputs:
                     partitioned = catalog._get_dataset(input)

--- a/kedro_partitioned/plugin.py
+++ b/kedro_partitioned/plugin.py
@@ -82,9 +82,16 @@ class MultiNodeEnabler:
                     assert isinstance(
                         partitioned, PartitionedDataset
                     ), "multinode cannot have non partitioned outputs"
-                    
-                    if not catalog.exists(slice):
-                        catalog.add(slice, deepcopy(partitioned))
+
+                    #if not catalog.exists(slice):
+
+                    cpy = deepcopy(partitioned)
+
+                    setattr(cpy, 'slice_id', node._slice_id)
+
+                    setattr(cpy, 'slice_count', node.slice_count)
+
+                    catalog.add(slice, deepcopy(partitioned))
 
                 for input in node.original_partitioned_inputs:
                     partitioned = catalog._get_dataset(input)


### PR DESCRIPTION
## Problem

-> Split is performing intersection before splitting
-> Load inputs in node (by multihtreading)
-> Apply processing to each partition individually


## Solution

-> Create option to provide custom splitting function
-> Create a decorator to load inputs by multithreading in node. Otherwize the feature is removed
-> Load en entire partition